### PR TITLE
Lucee dot notation settings to "Keep original case"

### DIFF
--- a/src/preside/_resources/lucee-web.xml.cfm
+++ b/src/preside/_resources/lucee-web.xml.cfm
@@ -73,5 +73,7 @@
 	<gateways/>
 
 	<orm/>
+	
+	<compiler dot-notation-upper-case="false" full-null-support="false" suppress-ws-before-arg="true"/>
 
 </lucee-configuration>


### PR DESCRIPTION
Lucee dot notation settings to "Keep original case"
