### PR TITLE
Fix to be able to use dependencies

### DIFF
--- a/preside/new/site.cfc
+++ b/preside/new/site.cfc
@@ -48,11 +48,9 @@ component extends="commandbox.system.BaseCommand" excludeFromHelp=false {
 
 		packageService.installPackage(
 			  id                      = arguments.skeleton
-			, directory               = directory
 			, save                    = false
 			, saveDev                 = false
 			, production              = true
-			, currentWorkingDirectory = directory
 		);
 
 		_runPostInstallScripts();


### PR DESCRIPTION
Supplying the directories to the installPackage method screwed the installation in case of defined dependencies (defined in the box.json file of the skeleton). For example the blog skeleton did not install properly - the 2 extensions install in the root directory.
