### PR TITLE
Feature additional trayoption preside

### DIFF
--- a/interceptors/PresideCommandsPostInstallInterceptor.cfc
+++ b/interceptors/PresideCommandsPostInstallInterceptor.cfc
@@ -21,6 +21,19 @@ component {
 		}
 	}
 
+	public void function onServerInstall( interceptData ) {
+		interceptData.serverInfo.trayOptions.prepend(
+			{
+				"label":"Preside",
+				"items": [
+					{ 'label':'Site Home', 'action':'openbrowser', 'url': interceptData.serverInfo.openbrowserURL },
+					{ 'label':'Site Admin', 'action':'openbrowser', 'url': '#interceptData.serverInfo.openbrowserURL#/#interceptData.serverInfo.name#_admin/' }
+				],
+				"image" : ""
+			}
+		);
+	}
+
 // PRIVATE HELPERS
 	private boolean function _isPresideApp( required string path ) {
 		var rootAppCfc = arguments.path.listAppend( "Application.cfc", "/" );


### PR DESCRIPTION
Add a additional `Preside` to the tray options, it contains 2 sub item
- Site home  : local with port, OOB feature
- Site admin : get the name of the server running and append '_admin' ( ###.#.#.#:####/{siteId}_admin ), so it only will function if the name of the server is same with the site id and admin path is set to {siteId}_admin

![preside trayicon](https://user-images.githubusercontent.com/50225529/63837692-8e46ae00-c9ae-11e9-8e35-221b4f0c9975.png)

Thank you
Brayden