### PR TITLE
Add dbdriver to data source definition.

### DIFF
--- a/commands/preside/start.cfc
+++ b/commands/preside/start.cfc
@@ -205,6 +205,6 @@ component {
 		if( !Len( Trim( host ) ) ) { host = "localhost"; }
 		if( !Len( Trim( port ) ) ) { port = "3306"; }
 
-		return '<data-source allow="511" blob="false" class="org.gjt.mm.mysql.Driver" clob="true" connectionLimit="-1" connectionTimeout="1" custom="useUnicode=true&amp;characterEncoding=UTF-8" database="#db#" dsn="jdbc:mysql://{host}:{port}/{database}" host="#host#" metaCacheTimeout="60000" name="preside" password="#pass#" port="#port#" storage="false" username="#usr#" validate="false"/>';
+		return '<data-source allow="511" blob="false" class="org.gjt.mm.mysql.Driver" clob="true" connectionLimit="-1" connectionTimeout="1" custom="useUnicode=true&amp;characterEncoding=UTF-8" database="#db#" dbdriver="mysql" dsn="jdbc:mysql://{host}:{port}/{database}" host="#host#" metaCacheTimeout="60000" name="preside" password="#pass#" port="#port#" storage="false" username="#usr#" validate="false"/>';
 	}
 }


### PR DESCRIPTION
The "preside" datasource that gets created when spinning up a new server had no `dbdriver` attribute assigned. While you can use CFConfig to export the datasource definition just fine, it will not import back into the Lucee web admin due to the missing attribute.
Adding `dbdriver=mysql` fixes this and makes moving around Preside configuration data with CFConfig a bit easier.