### PR TITLE
Fix get skeleton templates

### DIFF
--- a/commands/preside/new/site.cfc
+++ b/commands/preside/new/site.cfc
@@ -121,7 +121,7 @@ component {
 		if ( StructKeyExists( templates, "basic" ) ) {
 			ordered[ "basic" ] = templates.basic;
 		}
-		if ( StructKeyExists( templates, "basic" ) ) {
+		if ( StructKeyExists( templates, "webapp" ) ) {
 			ordered[ "webapp" ] = templates.webapp;
 		}
 		for( var key in templates ) {


### PR DESCRIPTION
Not a biggie as it only affects ordering. In this instance, the ordering is not affected at all (basic, webapp)